### PR TITLE
不正な正規表現によってクラッシュする問題を修正

### DIFF
--- a/frontend/src/utils/search.ts
+++ b/frontend/src/utils/search.ts
@@ -221,9 +221,7 @@ const matchesKeyword = (subject: Subject, options: SearchOptions) => {
 	// すなわち、"情報太郎" または "情報　太郎" で検索した場合も、"情報 太郎" にヒットさせる
 	const matchesPerson =
 		options.containsPerson &&
-		subject.person
-			.replace(" ", "")
-			.match(new RegExp(options.keyword.replace(/[ 　]/, ""), "i")) != null;
+		matchesSoftly(subject.person.replace(" ", ""), buildRegExp(options.keyword.replace(/[ 　]/, ""))) != null;
 
 	const matchesAbstract =
 		options.containsAbstract && matchesSoftly(subject.abstract, regex);

--- a/frontend/src/utils/search.ts
+++ b/frontend/src/utils/search.ts
@@ -164,6 +164,9 @@ const matchesSearchOptions = (
 	);
 };
 
+/** 失敗した正規表現のキャッシュ*/
+const regExpCaches: string[] = [];
+
 /**
  * エラーに寛容に正規表現を構築する
  * @param keyword
@@ -183,10 +186,18 @@ const buildRegExp = (keyword: string): RegExp | string => {
  */
 const matchesSoftly = (base: string, regex: string | RegExp): RegExpMatchArray | null => {
 	// 不正な正規表現等によってエラーが起きれば，単純に文字列どうしの部分一致をとる
+
+	// 失敗キャッシュがあればそれを返す
+	const keyword = typeof regex === 'string' ? regex : regex.source;
+	if (regExpCaches.includes(regex as string)) {
+		return base.includes(regex as string) ? [base] : null;
+	}
+
 	try {
 		return base.match(regex);
 	} catch {
-		return base.includes(typeof regex === 'string' ? regex : regex.source) ? [base] : null;
+		regExpCaches.push(keyword);
+		return base.includes(keyword) ? [base] : null;
 	}
 }
 


### PR DESCRIPTION
例えば `(` のみを入力した際，正規表現の構築またはマッチ時にエラーとなってクラッシュする問題があったため，エラー発生時には単純な部分一致をとって検索されるように修正した．